### PR TITLE
Fix line coloring

### DIFF
--- a/components/poem/Text.vue
+++ b/components/poem/Text.vue
@@ -215,7 +215,7 @@ onMounted(() => {
     <p class="text-[#007800] dark:text-[#4da14d]">Yes. Player…</p>
     <p>Use its name.</p>
     <p class="text-[#007800] dark:text-[#4da14d]">
-      {{ name }}
+      {{ name }}. Player of games.
     </p>
     <p>Good.</p>
     <p class="text-[#007800] dark:text-[#4da14d]">
@@ -241,7 +241,7 @@ onMounted(() => {
       Once upon a time, there was a player.
     </p>
     <p>
-      {{ name }}
+      The player was you, {{ name }}.
     </p>
     <p class="text-[#007800] dark:text-[#4da14d]">
       Sometimes it thought itself human, on the thin crust of a spinning globe
@@ -263,7 +263,7 @@ onMounted(() => {
       Sometimes the player woke from one dream into another, then woke from that
       into a third.
     </p>
-    <p>Sometimes the player dreamed it watched words on a screen</p>
+    <p>Sometimes the player dreamed it watched words on a screen.</p>
     <p class="text-[#007800] dark:text-[#4da14d]">Let's go back.</p>
     <p class="text-[#007800] dark:text-[#4da14d]">
       The atoms of the player were scattered in the grass, in the rivers, in the

--- a/components/poem/Text.vue
+++ b/components/poem/Text.vue
@@ -141,11 +141,8 @@ onMounted(() => {
       what true structure did this player create, in the reality behind the
       screen?
     </p>
-    <p class="text-[#007800] dark:text-[#4da14d]">
-      It worked, with a million others, to sculpt a true world in a fold of
-    </p>
     <p>
-      the
+      It worked, with a million others, to sculpt a true world in a fold of the
       <span class="inline-block w-16 text-center">{{ secrets.first }}, </span>
       and created a
       <span class="inline-block w-16 text-center">{{ secrets.second }}</span>
@@ -198,8 +195,10 @@ onMounted(() => {
     <p class="text-[#007800] dark:text-[#4da14d]">
       But it would be so easy to tell them...
     </p>
-    <p>Too strong for this dream. To tell them how to live is to prevent</p>
-    <p class="text-[#007800] dark:text-[#4da14d]">them living.</p>
+    <p>
+      Too strong for this dream. To tell them how to live is to prevent
+      them living.
+    </p>
     <p class="text-[#007800] dark:text-[#4da14d]">
       I will not tell the player how to live.
     </p>


### PR DESCRIPTION
- Fix coloring to attribute lines to the appropriate speaker
- Add some missing words

Cross referenced with the [Poem transcript](https://minecraft.wiki/w/Credit_sequence#Poem_transcript).